### PR TITLE
AIAT-130: Add ability to configure expected list of answers for a task

### DIFF
--- a/css/kort.css
+++ b/css/kort.css
@@ -126,3 +126,21 @@ h3.header {
 table.dataTable tbody td {
     vertical-align: middle;
 }
+
+.expected-answers {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    .list-group-item {
+        display: flex;
+        gap: 1rem;
+        align-items: baseline;
+    }
+}
+
+.icon-button {
+    display: flex;
+    gap: 0.5rem;
+    align-items: baseline;
+}

--- a/js/treetest-edit.js
+++ b/js/treetest-edit.js
@@ -49,8 +49,8 @@ function bindFunctions(){
     });
 
 	$("#tasks").on("click", ".addAnswerBtn", function () {
-		var node = $("#tree").jstree("get_selected");
-		var nodes = $('#tree').jstree('get_path', node, '/').split('/');
+		var node = $("#tree").jstree().get_selected();
+		var nodes = $('#tree').jstree().get_path(node);
 
 		expectedAnswersElement=$(this).closest('td').find('.expectedAnswers');
 		expectedAnswers = JSON.parse(expectedAnswersElement.val());

--- a/js/treetest-edit.js
+++ b/js/treetest-edit.js
@@ -64,13 +64,11 @@ function bindFunctions(){
 
 	$("#tasks").on("click", ".deleteAnswerBtn", function () {
 		const expectedAnswerContainer = $(this).closest("div");
-		const expectedAnswerText = expectedAnswerContainer.find('p').first();
+		const divIndex = expectedAnswerContainer.index();
 
 		const expectedAnswersElement=$(this).closest('td').find('.expectedAnswers');
-		expectedAnswers = JSON.parse(expectedAnswersElement.val());
-		expectedAnswers = expectedAnswers.filter(function(answer) {
-			return JSON.stringify(answer) != expectedAnswerText.text()
-		})
+		expectedAnswers = JSON.parse(expectedAnswersElement.val());		
+		expectedAnswers.splice(divIndex, 1);
 
 		expectedAnswersElement.val(JSON.stringify(expectedAnswers));
 		expectedAnswerContainer.remove();

--- a/js/treetest-edit.js
+++ b/js/treetest-edit.js
@@ -20,24 +20,56 @@ function bindFunctions(){
     	$('#form').submit()
 	});
 
-  $("#createNewRootNode").click(function() {
+  	$("#createNewRootNode").click(function() {
   		$('#tree').jstree().create_node("#", "New Root Item", "last");
 	});
 
 	//expand parent node when child is created
-  $("#createNewNode").click(function() {
-  	var selectedParent = $("#tree").jstree("get_selected");
-  	$('#tree').jstree().create_node(selectedParent, "New Item", "last");
-  	$("#tree").jstree("open_node", selectedParent);
+  	$("#createNewNode").click(function() {
+  		var selectedParent = $("#tree").jstree("get_selected");
+  		$('#tree').jstree().create_node(selectedParent, "New Item", "last");
+  		$("#tree").jstree("open_node", selectedParent);
 	});
 
-  $("#expandAll").click(function() {
-  	$("#tree").jstree('open_all');
+  	$("#expandAll").click(function() {
+  		$("#tree").jstree('open_all');
 	});
 
 	$('#tree').on("changed.jstree", function (e, data) {
 		$("#tree").jstree("toggle_node", data.selected);
 	});
+
+	$("#newTask").on("click", function() {
+		var newRow = document.getElementById('newTask').querySelector('template').content.cloneNode(true);
+		$("#tasks").children("tbody").append($(newRow));
+	});
+
+	$("#tasks").on("click", ".deleteTaskBtn", function () {
+        $(this).closest("tr").remove();   
+    });
+
+	$("#tasks").on("click", ".addAnswerBtn", function () {
+		var node = $("#tree").jstree("get_selected");
+		var nodePath = $('#tree').jstree('get_path', node)
+
+		expectedAnswersElement=$(this).closest('table').closest('td').find('.expectedAnswers');
+		expectedAnswers = expectedAnswersElement.val() + nodePath + ';';
+		expectedAnswersElement.val(expectedAnswers);
+
+		var answerElement = document.getElementById('newAnswer').querySelector('template').content.cloneNode(true);
+		answerElement.querySelector('button').textContent=nodePath;
+		$(this).closest('tr').find('.list-group').append($(answerElement));		
+    });
+
+	$("#tasks").on("click", ".deleteAnswerBtn", function () {
+		buttonElement = $(this).closest("button");
+		
+		expectedAnswersElement=$(this).closest('table').closest('td').find('.expectedAnswers');
+		expectedAnswers = expectedAnswersElement.val().replace(buttonElement.text() + ';', "");
+		expectedAnswersElement.val(expectedAnswers);
+		
+		buttonElement.remove();
+    });
 }
 
 $(function() {

--- a/js/treetest-edit.js
+++ b/js/treetest-edit.js
@@ -52,23 +52,24 @@ function bindFunctions(){
 		var node = $("#tree").jstree("get_selected");
 		var nodePath = $('#tree').jstree('get_path', node)
 
-		expectedAnswersElement=$(this).closest('table').closest('td').find('.expectedAnswers');
+		expectedAnswersElement=$('.expectedAnswers');
 		expectedAnswers = expectedAnswersElement.val() + nodePath + ';';
 		expectedAnswersElement.val(expectedAnswers);
 
 		var answerElement = document.getElementById('newAnswer').querySelector('template').content.cloneNode(true);
-		answerElement.querySelector('button').textContent=nodePath;
+		answerElement.querySelector('p').textContent=nodePath;
 		$(this).closest('tr').find('.list-group').append($(answerElement));		
     });
 
 	$("#tasks").on("click", ".deleteAnswerBtn", function () {
-		buttonElement = $(this).closest("button");
+		const expectedAnswerContainer = $(this).closest("div");
+		const expectedAnswerText = expectedAnswerContainer.find('p').first();
 		
-		expectedAnswersElement=$(this).closest('table').closest('td').find('.expectedAnswers');
-		expectedAnswers = expectedAnswersElement.val().replace(buttonElement.text() + ';', "");
+		const expectedAnswersElement=$('input[name=expectedAnswers]');
+		const expectedAnswers = expectedAnswersElement.val().replace(expectedAnswerText.text() + ';', "");
 		expectedAnswersElement.val(expectedAnswers);
 		
-		buttonElement.remove();
+		expectedAnswerContainer.remove();
     });
 }
 

--- a/js/treetest-edit.js
+++ b/js/treetest-edit.js
@@ -50,25 +50,29 @@ function bindFunctions(){
 
 	$("#tasks").on("click", ".addAnswerBtn", function () {
 		var node = $("#tree").jstree("get_selected");
-		var nodePath = $('#tree').jstree('get_path', node)
+		var nodes = $('#tree').jstree('get_path', node, '/').split('/');
 
-		expectedAnswersElement=$('.expectedAnswers');
-		expectedAnswers = expectedAnswersElement.val() + nodePath + ';';
-		expectedAnswersElement.val(expectedAnswers);
+		expectedAnswersElement=$(this).closest('td').find('.expectedAnswers');
+		expectedAnswers = JSON.parse(expectedAnswersElement.val());
+		expectedAnswers.push(nodes);
+		expectedAnswersElement.val(JSON.stringify(expectedAnswers));	
 
 		var answerElement = document.getElementById('newAnswer').querySelector('template').content.cloneNode(true);
-		answerElement.querySelector('p').textContent=nodePath;
-		$(this).closest('tr').find('.list-group').append($(answerElement));		
+		answerElement.querySelector('p').textContent=JSON.stringify(nodes);
+		$(this).closest('tr').find('.list-group').append($(answerElement));	
     });
 
 	$("#tasks").on("click", ".deleteAnswerBtn", function () {
 		const expectedAnswerContainer = $(this).closest("div");
 		const expectedAnswerText = expectedAnswerContainer.find('p').first();
-		
-		const expectedAnswersElement=$('input[name=expectedAnswers]');
-		const expectedAnswers = expectedAnswersElement.val().replace(expectedAnswerText.text() + ';', "");
-		expectedAnswersElement.val(expectedAnswers);
-		
+
+		const expectedAnswersElement=$(this).closest('td').find('.expectedAnswers');
+		expectedAnswers = JSON.parse(expectedAnswersElement.val());
+		expectedAnswers = expectedAnswers.filter(function(answer) {
+			return JSON.stringify(answer) != expectedAnswerText.text()
+		})
+
+		expectedAnswersElement.val(JSON.stringify(expectedAnswers));
 		expectedAnswerContainer.remove();
     });
 }

--- a/server/treetest_server.js
+++ b/server/treetest_server.js
@@ -59,7 +59,16 @@ module.exports = {
             data: {
                 showSiblings: true,
                 selectableParents: true,
-                tasks: ['Where is the Apple?','Where is the Bacon?'],
+                tasks: [
+                    {
+                        question: 'Where is the Apples?',
+                        expectedAnswers:['Fruits,Apple']
+                    },
+                    {
+                        question: 'Where is the Bacon?',
+                        expectedAnswers:['Meats,Bacon']
+                    }
+                ],
                 tree: JSON.stringify([{text:'Fruits',children:['Apple','Banana']},{text:'Meats',children:['Bacon','Turkey']}])
             },
             status: 'closed',
@@ -130,9 +139,17 @@ module.exports = {
         });
     },
     update: function (req, res, next) {
-        var tasks = req.body.tasks.split(/\r?\n/).map(function(item) {
-             return item.trim();
-        }).filter(function(n){ return n != '' });
+        var tasks = [];
+        for (var i = 0; i < req.body.question.length; i++) {
+            if (req.body.question[i] == '') {
+                continue;
+            } 
+
+            tasks[tasks.length] = {
+                question: req.body.question[i],
+                expectedAnswers: req.body.expectedAnswers[i].substring(0,req.body.expectedAnswers[i].length-1).split(';')
+            }            
+        }
 
         var clean_id = sanitize(req.body.id);
         var clean_ownerid = sanitize(req.user._id);

--- a/server/treetest_server.js
+++ b/server/treetest_server.js
@@ -139,12 +139,15 @@ module.exports = {
         });
     },
     update: function (req, res, next) {
+        //Updates the tasks and their expected answers for the respective tree test 
         var tasks = [];
         for (var i = 0; i < req.body.question.length; i++) {
-            if (req.body.question[i] == '') {
+            if (req.body.question[i].trim() == '') {
+                //Do not save the question and related answers if the question is empty or a whitespace
                 continue;
             } 
 
+            //Adds a new element to tasks array. Every element contains a string field for question and an array field for storing expected answers
             tasks[tasks.length] = {
                 question: req.body.question[i],
                 expectedAnswers: JSON.parse(req.body.expectedAnswers[i])
@@ -154,6 +157,8 @@ module.exports = {
         var clean_id = sanitize(req.body.id);
         var clean_ownerid = sanitize(req.user._id);
 
+        //Uses Mongoose Model.findOne() api function to get study document from the database with matching study id. 
+        //It then updates the retrieved study document with the captured form data and saves it back.
         Study.findOne({_id: clean_id, ownerID: clean_ownerid},
             function (err, study) {
             if (err) {

--- a/server/treetest_server.js
+++ b/server/treetest_server.js
@@ -62,11 +62,11 @@ module.exports = {
                 tasks: [
                     {
                         question: 'Where is the Apples?',
-                        expectedAnswers:['Fruits,Apple']
+                        expectedAnswers:[["Fruits", "Apple"]]
                     },
                     {
                         question: 'Where is the Bacon?',
-                        expectedAnswers:['Meats,Bacon']
+                        expectedAnswers:[["Meats", "Bacon"]]
                     }
                 ],
                 tree: JSON.stringify([{text:'Fruits',children:['Apple','Banana']},{text:'Meats',children:['Bacon','Turkey']}])
@@ -147,7 +147,7 @@ module.exports = {
 
             tasks[tasks.length] = {
                 question: req.body.question[i],
-                expectedAnswers: req.body.expectedAnswers[i].substring(0,req.body.expectedAnswers[i].length-1).split(';')
+                expectedAnswers: JSON.parse(req.body.expectedAnswers[i])
             }            
         }
 

--- a/server/treetest_server.js
+++ b/server/treetest_server.js
@@ -148,10 +148,12 @@ module.exports = {
             } 
 
             //Adds a new element to tasks array. Every element contains a string field for question and an array field for storing expected answers
-            tasks[tasks.length] = {
-                question: req.body.question[i],
-                expectedAnswers: JSON.parse(req.body.expectedAnswers[i])
-            }            
+            tasks.push(
+                {
+                    question: req.body.question[i],
+                    expectedAnswers: JSON.parse(req.body.expectedAnswers[i])
+                }
+            );           
         }
 
         var clean_id = sanitize(req.body.id);

--- a/views/treetest/edit.ejs
+++ b/views/treetest/edit.ejs
@@ -67,7 +67,7 @@
 									<tr>
 										<td><textarea name="question[]" style='width:100%' rows="2" cols="50"></textarea></td>
 										<td class="expected-answers">
-											<input hidden name='expectedAnswers' class='expectedAnswers'/>
+											<input hidden name='expectedAnswers[]' class='expectedAnswers' value="[]"/>
 											<div class="list-group">
 											</div>
 											<button id="newAnswer" type="button" class="addAnswerBtn btn btn-default">
@@ -93,15 +93,11 @@
 									<tr>
 										<td><textarea name="question[]" style='width:100%' rows="2" cols="50"><%= singleStudy.data.tasks[i].question %></textarea></td>
 										<td class="expected-answers">
-											<input hidden name='expectedAnswers' class='expectedAnswers' value="
-												<% for(var j=0; j<singleStudy.data.tasks[i].expectedAnswers.length; j++) {%>
-													<%= singleStudy.data.tasks[i].expectedAnswers[j]+';' %>
-												<% } %>
-											"/>
+											<input hidden name='expectedAnswers[]' class='expectedAnswers' value="<%= '[' + singleStudy.data.tasks[i].expectedAnswers.map(answer => JSON.stringify(answer)).join(',') + ']' %>"/>											
 											<div class="list-group">
 												<% for(var j=0; j<singleStudy.data.tasks[i].expectedAnswers.length; j++) {%>
 													<div class="list-group-item">
-														<p><%= singleStudy.data.tasks[i].expectedAnswers[j] %></p>
+														<p><%= JSON.stringify(singleStudy.data.tasks[i].expectedAnswers[j]) %></p>
 														<button type="button" class="deleteAnswerBtn btn btn-default icon-button">
 															<span class="fa fa-minus" aria-hidden="true"></span>
 															Remove

--- a/views/treetest/edit.ejs
+++ b/views/treetest/edit.ejs
@@ -60,7 +60,7 @@
 							<br>One task per line (task numbers will be added automatically).
 						</p>		
 						<p>			
-							<button id="newTask" type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="right" title="Adds a new task">
+							<button id="newTask" type="button" class="btn btn-secondary" data-bs-toggle="tooltip" data-bs-placement="right" title="Adds a new task">
 								<i class="fa fa-plus" aria-hidden="true"></i> 
 								New Task
 								<template>
@@ -75,7 +75,7 @@
 												Add answer
 											</button>
 										</td>
-										<td><button name="deletetask" type="button" class="deleteTaskBtn btn btn-default" data-toggle="tooltip" data-placement="right" title="Deletes the task"><i class="fa fa-trash"></i></button></td>
+										<td><button name="deletetask" type="button" class="deleteTaskBtn btn btn-default" data-bs-toggle="tooltip" data-bs-placement="right" title="Deletes the task"><i class="fa fa-trash"></i></button></td>
 									</tr>
 								</template>
 							</button>
@@ -119,7 +119,7 @@
 												</template>
 											</button>
 										</td>
-										<td><button name="deletetask" type="button" class="deleteTaskBtn btn btn-default" data-toggle="tooltip" data-placement="right" title="Deletes the task"><i class="fa fa-trash"></i></button></td>
+										<td><button name="deletetask" type="button" class="deleteTaskBtn btn btn-default" data-bs-toggle="tooltip" data-bs-placement="right" title="Deletes the task"><i class="fa fa-trash"></i></button></td>
 									</tr>
 								<% } %>
 							</tbody>

--- a/views/treetest/edit.ejs
+++ b/views/treetest/edit.ejs
@@ -65,26 +65,19 @@
 								New Task
 								<template>
 									<tr>
-										<td contenteditable='true'><textarea name="question[]" style='width:100%' rows="2" cols="50"></textarea></td>
-										<td>
-											<input hidden name='expectedAnswers[]' class='expectedAnswers'/>
-											<table class="table table-condensed">
-												<tr>
-													<td class="no-border" style="width:10%">
-														<button id="newAnswer" type="button" class="addAnswerBtn btn btn-default" data-toggle="tooltip" data-placement="right" title="Adds the selected tree node as the expected answer">
-															<i class="fa fa-plus" aria-hidden="true"></i> 
-														</button>
-													</td>
-													<td class="no-border">
-														<div class="list-group">
-														</div>
-													</td>
-												</tr>
-											</table>									
+										<td><textarea name="question[]" style='width:100%' rows="2" cols="50"></textarea></td>
+										<td class="expected-answers">
+											<input hidden name='expectedAnswers' class='expectedAnswers'/>
+											<div class="list-group">
+											</div>
+											<button id="newAnswer" type="button" class="addAnswerBtn btn btn-default">
+												<span class="fa fa-plus" aria-hidden="true"></span>
+												Add answer
+											</button>
 										</td>
 										<td><button name="deletetask" type="button" class="deleteTaskBtn btn btn-default" data-toggle="tooltip" data-placement="right" title="Deletes the task"><i class="fa fa-trash"></i></button></td>
 									</tr>
-								</template>						
+								</template>
 							</button>
 						</p>	
 						<table id="tasks" class="table table-striped">
@@ -98,28 +91,37 @@
 							<tbody>
 								<% for(var i=0; i<singleStudy.data.tasks.length; i++) {%>
 									<tr>
-										<td contenteditable='true'><textarea name="question[]" style='width:100%' rows="2" cols="50"><%= singleStudy.data.tasks[i].question %></textarea></td>
-										<td>
-											<input hidden name='expectedAnswers[]' class='expectedAnswers' value="<% for(var j=0; j<singleStudy.data.tasks[i].expectedAnswers.length; j++) {%><%= singleStudy.data.tasks[i].expectedAnswers[j]+';' %><% } %>"/>
-											<table class="table table-condensed">
-												<tr>
-													<td class="no-border" style="width:10%">
-														<button id="newAnswer" type="button" class="addAnswerBtn btn btn-default" data-toggle="tooltip" data-placement="right" title="Adds the selected tree node as the expected answer">
-															<i class="fa fa-plus" aria-hidden="true"></i>
-															<template>
-																<button type="button" class="deleteAnswerBtn list-group-item list-group-item-action" data-toggle="tooltip" data-placement="right" title="Deletes the answer when clicked">tt</button>
-															</template>	 
+										<td><textarea name="question[]" style='width:100%' rows="2" cols="50"><%= singleStudy.data.tasks[i].question %></textarea></td>
+										<td class="expected-answers">
+											<input hidden name='expectedAnswers' class='expectedAnswers' value="
+												<% for(var j=0; j<singleStudy.data.tasks[i].expectedAnswers.length; j++) {%>
+													<%= singleStudy.data.tasks[i].expectedAnswers[j]+';' %>
+												<% } %>
+											"/>
+											<div class="list-group">
+												<% for(var j=0; j<singleStudy.data.tasks[i].expectedAnswers.length; j++) {%>
+													<div class="list-group-item">
+														<p><%= singleStudy.data.tasks[i].expectedAnswers[j] %></p>
+														<button type="button" class="deleteAnswerBtn btn btn-default icon-button">
+															<span class="fa fa-minus" aria-hidden="true"></span>
+															Remove
 														</button>
-													</td>
-													<td class="no-border">
-														<div class="list-group">
-															<% for(var j=0; j<singleStudy.data.tasks[i].expectedAnswers.length; j++) {%>
-																<button type="button" class="deleteAnswerBtn list-group-item list-group-item-action" data-toggle="tooltip" data-placement="right" title="Deletes the answer when clicked"><%= singleStudy.data.tasks[i].expectedAnswers[j] %></button>
-															<% } %>
-														</div>
-													</td>
-												</tr>
-											</table>										
+													</div>
+												<% } %>
+											</div>
+											<button id="newAnswer" type="button" class="addAnswerBtn btn btn-default">
+												<span class="fa fa-plus" aria-hidden="true"></span>
+												Add answer
+												<template>
+													<div class="list-group-item">
+														<p></p>
+														<button type="button" class="deleteAnswerBtn btn btn-default">
+															<span class="fa fa-minus" aria-hidden="true"></span>
+															Remove
+														</button>
+													</div>
+												</template>
+											</button>
 										</td>
 										<td><button name="deletetask" type="button" class="deleteTaskBtn btn btn-default" data-toggle="tooltip" data-placement="right" title="Deletes the task"><i class="fa fa-trash"></i></button></td>
 									</tr>

--- a/views/treetest/edit.ejs
+++ b/views/treetest/edit.ejs
@@ -45,7 +45,7 @@
 					      <p>When an element is expanded, other elements on that level will be hidden. This can be useful for viewing large structures.</p>
 					    </div>
 					    <% } else { %>
-					   <div class="checkbox">
+					   	<div class="checkbox">
 					      <label><input type="checkbox" name="showSiblings">Hide Siblings</label>
 					        <p>When an element is expanded, other elements on that level will be hidden. This can be useful for viewing large structures.</p>
 					    </div>
@@ -55,9 +55,77 @@
 				</div>
 				<div class='col-sm-8'>
 					<div class="well">
-						<p><label for="tasks">Tasks</label>
-						<br>One task per line (task numbers will be added automatically).</p>
-						<textarea style='width:100%' name="tasks" rows="15" cols="30" id="tasks"><% for(var j=0; j<singleStudy.data.tasks.length; j++) {%><%= singleStudy.data.tasks[j]+'\n' %><% } %></textarea>
+						<p>
+							<label for="tasks">Tasks</label>
+							<br>One task per line (task numbers will be added automatically).
+						</p>		
+						<p>			
+							<button id="newTask" type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="right" title="Adds a new task">
+								<i class="fa fa-plus" aria-hidden="true"></i> 
+								New Task
+								<template>
+									<tr>
+										<td contenteditable='true'><textarea name="question[]" style='width:100%' rows="2" cols="50"></textarea></td>
+										<td>
+											<input hidden name='expectedAnswers[]' class='expectedAnswers'/>
+											<table class="table table-condensed">
+												<tr>
+													<td class="no-border" style="width:10%">
+														<button id="newAnswer" type="button" class="addAnswerBtn btn btn-default" data-toggle="tooltip" data-placement="right" title="Adds the selected tree node as the expected answer">
+															<i class="fa fa-plus" aria-hidden="true"></i> 
+														</button>
+													</td>
+													<td class="no-border">
+														<div class="list-group">
+														</div>
+													</td>
+												</tr>
+											</table>									
+										</td>
+										<td><button name="deletetask" type="button" class="deleteTaskBtn btn btn-default" data-toggle="tooltip" data-placement="right" title="Deletes the task"><i class="fa fa-trash"></i></button></td>
+									</tr>
+								</template>						
+							</button>
+						</p>	
+						<table id="tasks" class="table table-striped">
+							<thead>
+								<tr>
+									<th style="width:50%">Question</th>
+									<th style="width:45%">Expected Answers</th>
+									<th style="width:5%"></th>
+								</tr>
+							</thead>
+							<tbody>
+								<% for(var i=0; i<singleStudy.data.tasks.length; i++) {%>
+									<tr>
+										<td contenteditable='true'><textarea name="question[]" style='width:100%' rows="2" cols="50"><%= singleStudy.data.tasks[i].question %></textarea></td>
+										<td>
+											<input hidden name='expectedAnswers[]' class='expectedAnswers' value="<% for(var j=0; j<singleStudy.data.tasks[i].expectedAnswers.length; j++) {%><%= singleStudy.data.tasks[i].expectedAnswers[j]+';' %><% } %>"/>
+											<table class="table table-condensed">
+												<tr>
+													<td class="no-border" style="width:10%">
+														<button id="newAnswer" type="button" class="addAnswerBtn btn btn-default" data-toggle="tooltip" data-placement="right" title="Adds the selected tree node as the expected answer">
+															<i class="fa fa-plus" aria-hidden="true"></i>
+															<template>
+																<button type="button" class="deleteAnswerBtn list-group-item list-group-item-action" data-toggle="tooltip" data-placement="right" title="Deletes the answer when clicked">tt</button>
+															</template>	 
+														</button>
+													</td>
+													<td class="no-border">
+														<div class="list-group">
+															<% for(var j=0; j<singleStudy.data.tasks[i].expectedAnswers.length; j++) {%>
+																<button type="button" class="deleteAnswerBtn list-group-item list-group-item-action" data-toggle="tooltip" data-placement="right" title="Deletes the answer when clicked"><%= singleStudy.data.tasks[i].expectedAnswers[j] %></button>
+															<% } %>
+														</div>
+													</td>
+												</tr>
+											</table>										
+										</td>
+										<td><button name="deletetask" type="button" class="deleteTaskBtn btn btn-default" data-toggle="tooltip" data-placement="right" title="Deletes the task"><i class="fa fa-trash"></i></button></td>
+									</tr>
+								<% } %>
+							</tbody>
+						</table>
 					</div>
 				</div>
 			</div>

--- a/views/treetest/results.ejs
+++ b/views/treetest/results.ejs
@@ -57,7 +57,7 @@
 					<% for(var i=0; i < taskSet.length; i++) {%>
 					<tr>
 						<td><%= i+1 %></td>
-						<td><%= study.data.tasks[i] %></td>
+						<td><%= study.data.tasks[i].question %></td>
 						<td style="width:80%">
 							<table class="table table-condensed">
 							<% for(var j=0; j < taskSet[i].length; j++) {%>

--- a/views/treetest/view.ejs
+++ b/views/treetest/view.ejs
@@ -13,7 +13,7 @@
 	</head>
 
 	<body class="background-darkbluegray">
-		<div id="studyTasks" data-value="<% for(var i=0; i<singleStudy.data.tasks.length; i++) {%><%= singleStudy.data.tasks[i] %>;<% } %>"></div>
+		<div id="studyTasks" data-value="<% for(var i=0; i<singleStudy.data.tasks.length; i++) {%><%= singleStudy.data.tasks[i].question %>;<% } %>"></div>
 		<div id="selectableParents" data-value="<%= singleStudy.data.selectableParents %>"></div>
 		<div id="showSiblings" data-value="<%= singleStudy.data.showSiblings %>"></div>
 


### PR DESCRIPTION
- Updated tree test edit page to allow users to be able to configure expected list of answers for a task.
- Updated task schema in MongoDB to capture this information
- Updated other pages to work with the new task schema