### PR TITLE
AIAT-130 / Suggested frontend changes

### DIFF
--- a/css/kort.css
+++ b/css/kort.css
@@ -126,3 +126,21 @@ h3.header {
 table.dataTable tbody td {
     vertical-align: middle;
 }
+
+.expected-answers {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    .list-group-item {
+        display: flex;
+        gap: 1rem;
+        align-items: baseline;
+    }
+}
+
+.icon-button {
+    display: flex;
+    gap: 0.5rem;
+    align-items: baseline;
+}

--- a/js/treetest-edit.js
+++ b/js/treetest-edit.js
@@ -52,23 +52,24 @@ function bindFunctions(){
 		var node = $("#tree").jstree("get_selected");
 		var nodePath = $('#tree').jstree('get_path', node)
 
-		expectedAnswersElement=$(this).closest('table').closest('td').find('.expectedAnswers');
+		expectedAnswersElement=$('.expectedAnswers');
 		expectedAnswers = expectedAnswersElement.val() + nodePath + ';';
 		expectedAnswersElement.val(expectedAnswers);
 
 		var answerElement = document.getElementById('newAnswer').querySelector('template').content.cloneNode(true);
-		answerElement.querySelector('button').textContent=nodePath;
+		answerElement.querySelector('p').textContent=nodePath;
 		$(this).closest('tr').find('.list-group').append($(answerElement));		
     });
 
 	$("#tasks").on("click", ".deleteAnswerBtn", function () {
-		buttonElement = $(this).closest("button");
+		const expectedAnswerContainer = $(this).closest("div");
+		const expectedAnswerText = expectedAnswerContainer.find('p').first();
 		
-		expectedAnswersElement=$(this).closest('table').closest('td').find('.expectedAnswers');
-		expectedAnswers = expectedAnswersElement.val().replace(buttonElement.text() + ';', "");
+		const expectedAnswersElement=$('input[name=expectedAnswers]');
+		const expectedAnswers = expectedAnswersElement.val().replace(expectedAnswerText.text() + ';', "");
 		expectedAnswersElement.val(expectedAnswers);
 		
-		buttonElement.remove();
+		expectedAnswerContainer.remove();
     });
 }
 

--- a/views/treetest/edit.ejs
+++ b/views/treetest/edit.ejs
@@ -65,26 +65,19 @@
 								New Task
 								<template>
 									<tr>
-										<td contenteditable='true'><textarea name="question[]" style='width:100%' rows="2" cols="50"></textarea></td>
-										<td>
-											<input hidden name='expectedAnswers[]' class='expectedAnswers'/>
-											<table class="table table-condensed">
-												<tr>
-													<td class="no-border" style="width:10%">
-														<button id="newAnswer" type="button" class="addAnswerBtn btn btn-default" data-toggle="tooltip" data-placement="right" title="Adds the selected tree node as the expected answer">
-															<i class="fa fa-plus" aria-hidden="true"></i> 
-														</button>
-													</td>
-													<td class="no-border">
-														<div class="list-group">
-														</div>
-													</td>
-												</tr>
-											</table>									
+										<td><textarea name="question[]" style='width:100%' rows="2" cols="50"></textarea></td>
+										<td class="expected-answers">
+											<input hidden name='expectedAnswers' class='expectedAnswers'/>
+											<div class="list-group">
+											</div>
+											<button id="newAnswer" type="button" class="addAnswerBtn btn btn-default">
+												<span class="fa fa-plus" aria-hidden="true"></span>
+												Add answer
+											</button>
 										</td>
 										<td><button name="deletetask" type="button" class="deleteTaskBtn btn btn-default" data-toggle="tooltip" data-placement="right" title="Deletes the task"><i class="fa fa-trash"></i></button></td>
 									</tr>
-								</template>						
+								</template>
 							</button>
 						</p>	
 						<table id="tasks" class="table table-striped">
@@ -98,28 +91,37 @@
 							<tbody>
 								<% for(var i=0; i<singleStudy.data.tasks.length; i++) {%>
 									<tr>
-										<td contenteditable='true'><textarea name="question[]" style='width:100%' rows="2" cols="50"><%= singleStudy.data.tasks[i].question %></textarea></td>
-										<td>
-											<input hidden name='expectedAnswers[]' class='expectedAnswers' value="<% for(var j=0; j<singleStudy.data.tasks[i].expectedAnswers.length; j++) {%><%= singleStudy.data.tasks[i].expectedAnswers[j]+';' %><% } %>"/>
-											<table class="table table-condensed">
-												<tr>
-													<td class="no-border" style="width:10%">
-														<button id="newAnswer" type="button" class="addAnswerBtn btn btn-default" data-toggle="tooltip" data-placement="right" title="Adds the selected tree node as the expected answer">
-															<i class="fa fa-plus" aria-hidden="true"></i>
-															<template>
-																<button type="button" class="deleteAnswerBtn list-group-item list-group-item-action" data-toggle="tooltip" data-placement="right" title="Deletes the answer when clicked">tt</button>
-															</template>	 
+										<td><textarea name="question[]" style='width:100%' rows="2" cols="50"><%= singleStudy.data.tasks[i].question %></textarea></td>
+										<td class="expected-answers">
+											<input hidden name='expectedAnswers' class='expectedAnswers' value="
+												<% for(var j=0; j<singleStudy.data.tasks[i].expectedAnswers.length; j++) {%>
+													<%= singleStudy.data.tasks[i].expectedAnswers[j]+';' %>
+												<% } %>
+											"/>
+											<div class="list-group">
+												<% for(var j=0; j<singleStudy.data.tasks[i].expectedAnswers.length; j++) {%>
+													<div class="list-group-item">
+														<p><%= singleStudy.data.tasks[i].expectedAnswers[j] %></p>
+														<button type="button" class="deleteAnswerBtn btn btn-default icon-button">
+															<span class="fa fa-minus" aria-hidden="true"></span>
+															Remove
 														</button>
-													</td>
-													<td class="no-border">
-														<div class="list-group">
-															<% for(var j=0; j<singleStudy.data.tasks[i].expectedAnswers.length; j++) {%>
-																<button type="button" class="deleteAnswerBtn list-group-item list-group-item-action" data-toggle="tooltip" data-placement="right" title="Deletes the answer when clicked"><%= singleStudy.data.tasks[i].expectedAnswers[j] %></button>
-															<% } %>
-														</div>
-													</td>
-												</tr>
-											</table>										
+													</div>
+												<% } %>
+											</div>
+											<button id="newAnswer" type="button" class="addAnswerBtn btn btn-default">
+												<span class="fa fa-plus" aria-hidden="true"></span>
+												Add answer
+												<template>
+													<div class="list-group-item">
+														<p></p>
+														<button type="button" class="deleteAnswerBtn btn btn-default">
+															<span class="fa fa-minus" aria-hidden="true"></span>
+															Remove
+														</button>
+													</div>
+												</template>
+											</button>
 										</td>
 										<td><button name="deletetask" type="button" class="deleteTaskBtn btn btn-default" data-toggle="tooltip" data-placement="right" title="Deletes the task"><i class="fa fa-trash"></i></button></td>
 									</tr>


### PR DESCRIPTION
**Previously**, the expected answers list was a `<table>`. I thought this didn't make much sense, as this element doesn't communicate tabular data, and the `<table>` seemed to just be there for layout. I think tables used just for layout can have inflexible layout and be potentially inaccessible. (There's a good [discussion about layout tables on WebAIM](https://webaim.org/techniques/tables).) **Now**, the expected answers list is a `<div>`.

**Previously**, each expected answer was represented as a button, and clicking the button removed the expected answer from the list. I found this surprising. **Now**, each expected answer is represented as text, and next to the text is a button which says 'Remove', and clicking on the 'Remove' button removes the expected answer from the list. I think this is more intuitive.

**Previously**, the button for adding a new expected answer had no text content, and I found that made it hard to understand what it did. **Now**, it says 'Add answer', which I think makes it easier to understand what the button does.

I did also think it would be more intuitive to use a drop-down input or a text input with validation rather than adding the currently selected node, but that seemed to me like more work than it was worth.

Before:

![image](https://github.com/ScottLogic/kort/assets/118172583/6db5d280-bb63-49d2-9ed2-16f07177458a)

After:

![image](https://github.com/ScottLogic/kort/assets/118172583/a66b69af-2f20-475a-8867-68c880e77ba3)