### PR TITLE
AIAT-129 / Time tracking (socket.io implementation)

### DIFF
--- a/app.js
+++ b/app.js
@@ -73,6 +73,7 @@ const clientP = mongoose.connect(mongoURL).then(m => m.connection.getClient())
 require('./models/user');
 require('./models/study');
 require('./models/upload');
+require('./models/event');
 
 //setup a default admin account in Mongo
 require('./server/createadmin_user')(adminUser, adminPassword);

--- a/app.js
+++ b/app.js
@@ -134,6 +134,12 @@ app.use(bodyParser.json());
 
 require('./server/routes.js')(app, passport, flash, allowGoogleAuth, allowUserRegistration);
 
-app.listen(port, function () {
+const { createServer } = require('node:http');
+const httpServer = createServer(app);
+
+const { setupSocketServer } = require('./server/socket.js');
+setupSocketServer(httpServer);
+
+httpServer.listen(port, function () {
 	logger.info('Kort running on port: ' + port);
 });

--- a/js/treetest.js
+++ b/js/treetest.js
@@ -58,11 +58,8 @@ function bindNodeSelection(){
 }
 
 function resetTree(){
-	const { emitCloseNodeEvent } = socket;
-	socket.emitCloseNodeEvent = () => {};
 	$('#tree').jstree('close_all');
 	disableButton('#nextTaskButton');
-	socket.emitCloseNodeEvent = emitCloseNodeEvent;
 }
 
 function setHistory(node){
@@ -124,7 +121,18 @@ var tasks = {
 		this.idx = number;
 		$('#taskDesc').html(this.list[number]);
 		$('#taskNum').html("Task "+(number+1)+" of "+this.list.length);
+
+		// Resetting the tree between tasks results in all open nodes closing, but
+		// we don't want to register these as close node events, because they aren't
+		// meaningfully user actions. So we pause listening for close node events
+		const { emitCloseNodeEvent } = socket;
+		socket.emitCloseNodeEvent = () => {};
+
 		resetTree();
+
+		// Start listening for close node events again
+		socket.emitCloseNodeEvent = emitCloseNodeEvent;
+
 		if(this.answers[this.idx].length > 0){
 			//need to pass a copy of node path to expandToNode (or else it alters tasks.answers)
 			var copyOfHistory = $.extend(true, [], this.answers[this.idx]);

--- a/js/treetest.js
+++ b/js/treetest.js
@@ -58,8 +58,11 @@ function bindNodeSelection(){
 }
 
 function resetTree(){
+	const { emitCloseNodeEvent } = socket;
+	socket.emitCloseNodeEvent = () => {};
 	$('#tree').jstree('close_all');
 	disableButton('#nextTaskButton');
+	socket.emitCloseNodeEvent = emitCloseNodeEvent;
 }
 
 function setHistory(node){

--- a/js/treetest.js
+++ b/js/treetest.js
@@ -185,6 +185,11 @@ var socket = {
 		this._emitEvent({ answers }, 'submit response');
 	},
 
+	emitWindowVisibilityChangedEvent: function(newVisibilityState) {
+		const data = { new_visibility_state: newVisibilityState };
+		this._emitEvent(data, 'window visibility changed');
+	},
+
 	_emitEvent: function(data, eventType) {
 		const json = JSON.stringify({
 			id: crypto.randomUUID(),
@@ -233,6 +238,7 @@ function bindEvents() {
 	bindEmitOnCloseNode();
 	bindEmitOnTaskChanged();
 	bindEmitOnSubmitResponse();
+	bindEmitOnWindowVisibilityChanged();
 }
 
 function bindEmitOnActivateNode() {
@@ -264,4 +270,10 @@ function bindEmitOnTaskChanged() {
 
 function bindEmitOnSubmitResponse() {
 	tasks.onSubmit.push(answers => socket.emitSubmitResponseEvent(answers));
+}
+
+function bindEmitOnWindowVisibilityChanged() {
+	document.addEventListener('visibilitychange', () => {
+		socket.emitWindowVisibilityChangedEvent(document.visibilityState);
+	});
 }

--- a/js/treetest.js
+++ b/js/treetest.js
@@ -158,7 +158,7 @@ var socket = {
 	emitActivateNodeEvent: function(node) {
 		const data = {
 			node: $('#tree').jstree().get_path(node),
-			current_task_index: tasks.idx,
+			currentTaskIndex: tasks.idx,
 		};
 		this._emitEvent(data, 'activate node');
 	},
@@ -166,7 +166,7 @@ var socket = {
 	emitOpenNodeEvent: function(node) {
 		const data = {
 			node: $('#tree').jstree().get_path(node),
-			current_task_index: tasks.idx,
+			currentTaskIndex: tasks.idx,
 		};
 		this._emitEvent(data, 'open node');
 	},
@@ -174,13 +174,13 @@ var socket = {
 	emitCloseNodeEvent: function(node) {
 		const data = {
 			node: $('#tree').jstree().get_path(node),
-			current_task_index: tasks.idx,
+			currentTaskIndex: tasks.idx,
 		};
 		this._emitEvent(data, 'close node');
 	},
 
 	emitTaskChangedEvent: function(newTaskIndex) {
-		this._emitEvent({ new_task_index: newTaskIndex }, 'task changed');
+		this._emitEvent({ newTaskIndex }, 'task changed');
 	},
 
 	emitSubmitResponseEvent: function(answers) {
@@ -188,7 +188,7 @@ var socket = {
 	},
 
 	emitWindowVisibilityChangedEvent: function(newVisibilityState) {
-		const data = { new_visibility_state: newVisibilityState };
+		const data = { newVisibilityState };
 		this._emitEvent(data, 'window visibility changed');
 	},
 
@@ -196,7 +196,7 @@ var socket = {
 		const json = JSON.stringify({
 			id: crypto.randomUUID(),
 			timestamp: new Date().toISOString(),
-			response_id: responseId,
+			responseId,
 			...data,
 		});
 		const emitUntilAcknowledged = () => this._socket

--- a/js/treetest.js
+++ b/js/treetest.js
@@ -127,6 +127,21 @@ var tasks = {
 		}
 	}
 }
+
+var socket = {
+	_socket: null,
+
+	connect: function() {
+		this._socket = io();
+		this._socket.on('connect', () => {
+			console.debug('Socket connected');
+			this._socket.on('disconnect', () => {
+				console.debug('Socket disconnected');
+			})
+		})
+	},
+}
+
 //---------------------Task List Initialization----------------------
 function setup(input_tasks,input_tree,input_selectableParents,input_closeSiblings){
 	var tasksDB = input_tasks.split(";").map(function(item) {
@@ -150,4 +165,6 @@ function setup(input_tasks,input_tree,input_selectableParents,input_closeSibling
 	tasks.set(0);
 	disableButton('#nextTaskButton');
 	bindNextButton();
+
+	socket.connect();
 }

--- a/js/treetest.js
+++ b/js/treetest.js
@@ -141,6 +141,10 @@ var socket = {
 		})
 	},
 
+	emitPageLoadEvent: function() {
+		this._emitEvent({}, 'page load');
+	},
+
 	_emitEvent: function(data, eventType) {
 		const json = JSON.stringify({
 			id: crypto.randomUUID(),
@@ -180,4 +184,5 @@ function setup(input_tasks,input_tree,input_selectableParents,input_closeSibling
 	bindNextButton();
 
 	socket.connect();
+	socket.emitPageLoadEvent();
 }

--- a/js/treetest.js
+++ b/js/treetest.js
@@ -144,8 +144,8 @@ var socket = {
 		this._socket.on('connect', () => {
 			console.debug('Socket connected');
 		});
-		this._socket.on('disconnect', () => {
-			console.debug('Socket disconnected');
+		this._socket.on('disconnect', (reason) => {
+			console.debug(`Socket disconnected. Reason: ${reason}`);
 		});
 	},
 

--- a/js/treetest.js
+++ b/js/treetest.js
@@ -194,7 +194,7 @@ var socket = {
 		const json = JSON.stringify({
 			id: crypto.randomUUID(),
 			timestamp: new Date().toISOString(),
-			tree_test_id: document.split('/').pop(),
+			tree_test_id: document.baseURI.split('/').pop(),
 			...data,
 		});
 		const emitUntilAcknowledged = () => this._socket

--- a/js/treetest.js
+++ b/js/treetest.js
@@ -194,7 +194,7 @@ var socket = {
 		const json = JSON.stringify({
 			id: crypto.randomUUID(),
 			timestamp: new Date().toISOString(),
-			tree_test_id: document.baseURI.split('/').pop(),
+			response_id: document.baseURI.split('/').pop(),
 			...data,
 		});
 		const emitUntilAcknowledged = () => this._socket

--- a/js/treetest.js
+++ b/js/treetest.js
@@ -272,7 +272,7 @@ function bindEmitOnCloseNode() {
 }
 
 function bindEmitOnTaskChanged() {
-	window.addEventListener('taskchanged', ({ detail }) => socket.emitTaskChangedEvent(detail.newTaskIndex));
+	window.addEventListener('taskchanged', ({ detail }) => socket.emitTaskChangedEvent(detail.newTaskIndex + 1));
 }
 
 function bindEmitOnSubmitResponse() {

--- a/js/treetest.js
+++ b/js/treetest.js
@@ -143,10 +143,10 @@ var socket = {
 		this._socket = io();
 		this._socket.on('connect', () => {
 			console.debug('Socket connected');
-			this._socket.on('disconnect', () => {
-				console.debug('Socket disconnected');
-			})
-		})
+		});
+		this._socket.on('disconnect', () => {
+			console.debug('Socket disconnected');
+		});
 	},
 
 	emitPageLoadEvent: function() {

--- a/js/treetest.js
+++ b/js/treetest.js
@@ -102,7 +102,7 @@ var tasks = {
 			updateProgressBar();
 		} else {
 			$('#hiddenResults').val(JSON.stringify(tasks.answers));
-			this.onSubmit.forEach(callback => callback(tasks.answers));
+			window.dispatchEvent(new CustomEvent('submittask', { answers: this.answers }));
 			$('#submitForm').click();
 		}
 		if (this.idx == this.list.length-1){
@@ -138,10 +138,9 @@ var tasks = {
 			var copyOfHistory = $.extend(true, [], this.answers[this.idx]);
 			expandToNode(copyOfHistory);
 		}
-		this.onSet.forEach(callback => callback(number));
+
+		window.dispatchEvent(new CustomEvent('taskchanged', { newTaskIndex: number }));
 	},
-	onSet: [],
-	onSubmit: [],
 }
 
 var socket = {
@@ -273,11 +272,11 @@ function bindEmitOnCloseNode() {
 }
 
 function bindEmitOnTaskChanged() {
-	tasks.onSet.push(number => socket.emitTaskChangedEvent(number));
+	window.addEventListener('taskchanged', ({ newTaskIndex }) => socket.emitTaskChangedEvent(newTaskIndex));
 }
 
 function bindEmitOnSubmitResponse() {
-	tasks.onSubmit.push(answers => socket.emitSubmitResponseEvent(answers));
+	window.addEventListener('submittask', ({ answers }) => socket.emitSubmitResponseEvent(answers));
 }
 
 function bindEmitOnWindowVisibilityChanged() {

--- a/js/treetest.js
+++ b/js/treetest.js
@@ -7,6 +7,7 @@ function bindNextButton(){
 		}
 	});
 }
+
 function bindCloseSiblingsOnOpen(){
 	$('#tree').on("before_open.jstree", function (e, data) {
 		var siblings = $("#tree").jstree("get_node", data.node.parent).children;
@@ -15,6 +16,7 @@ function bindCloseSiblingsOnOpen(){
 		})
 	});
 }
+
 function initializeTreeViewObject(treeStructure){
 	$('#tree').jstree({
 		"core" : {
@@ -32,32 +34,38 @@ function initializeTreeViewObject(treeStructure){
 		$("#tree").jstree('close_all');
 	});
 }
+
 function enableButton(buttonID){
 	$(buttonID).removeClass('disabled');
 	$(buttonID).addClass('btn-amber');
 }
+
 function disableButton(buttonID){
 	$(buttonID).removeClass('btn-amber');
 	$(buttonID).addClass('disabled');
 }
+
 function bindNodeSelection(){
 	//When node is selected (clicked), write full path of node ids
 	$('#tree').on("select_node.jstree", function (e, data) {
-	  tasks.answers[tasks.idx] = setHistory(data.node)
-	  	enableButton('#nextTaskButton');
+		tasks.answers[tasks.idx] = setHistory(data.node);
+		enableButton('#nextTaskButton');
 	});
 	$('#tree').on("deselect_node.jstree", function (e, data) {
 	  disableButton('#nextTaskButton');
 	});
 }
+
 function resetTree(){
 	$('#tree').jstree('close_all');
 	disableButton('#nextTaskButton');
 }
+
 function setHistory(node){
 	var path = $('#tree').jstree('get_path',node);
 	return path;
 }
+
 function singleClickExpand(parents) {
 	$('#tree').on("changed.jstree", function (e, data) {
 		$("#tree").jstree("toggle_node", data.selected);
@@ -69,11 +77,13 @@ function singleClickExpand(parents) {
 		}
 	});
 }
+
 function updateProgressBar(){
 	var status = ((tasks.idx/tasks.list.length)*100)+'%';
 	$('#progressbar').css("width", status);
 	$('#progressbar').html('');
 }
+
 //--------------------------Task JS Object---------------------------
 //tasks js object to store task related functions and data
 var tasks = {

--- a/js/treetest.js
+++ b/js/treetest.js
@@ -163,7 +163,7 @@ var socket = {
 	emitActivateNodeEvent: function(node) {
 		const data = {
 			node: $('#tree').jstree().get_path(node),
-			currentTaskIndex: tasks.idx,
+			currentTaskIndex: tasks.idx + 1,
 		};
 		this._emitEvent(data, 'activate node');
 	},
@@ -171,7 +171,7 @@ var socket = {
 	emitOpenNodeEvent: function(node) {
 		const data = {
 			node: $('#tree').jstree().get_path(node),
-			currentTaskIndex: tasks.idx,
+			currentTaskIndex: tasks.idx + 1,
 		};
 		this._emitEvent(data, 'open node');
 	},
@@ -179,7 +179,7 @@ var socket = {
 	emitCloseNodeEvent: function(node) {
 		const data = {
 			node: $('#tree').jstree().get_path(node),
-			currentTaskIndex: tasks.idx,
+			currentTaskIndex: tasks.idx + 1,
 		};
 		this._emitEvent(data, 'close node');
 	},

--- a/js/treetest.js
+++ b/js/treetest.js
@@ -105,6 +105,7 @@ var tasks = {
 			updateProgressBar();
 		} else {
 			$('#hiddenResults').val(JSON.stringify(tasks.answers));
+			this.onSubmit.forEach(callback => callback(tasks.answers));
 			$('#submitForm').click();
 		}
 		if (this.idx == this.list.length-1){
@@ -132,6 +133,7 @@ var tasks = {
 		this.onSet.forEach(callback => callback(number));
 	},
 	onSet: [],
+	onSubmit: [],
 }
 
 var socket = {
@@ -177,6 +179,10 @@ var socket = {
 
 	emitTaskChangedEvent: function(newTaskIndex) {
 		this._emitEvent({ new_task_index: newTaskIndex }, 'task changed');
+	},
+
+	emitSubmitResponseEvent: function(answers) {
+		this._emitEvent({ answers }, 'submit response');
 	},
 
 	_emitEvent: function(data, eventType) {
@@ -226,6 +232,7 @@ function bindEvents() {
 	bindEmitOnOpenNode();
 	bindEmitOnCloseNode();
 	bindEmitOnTaskChanged();
+	bindEmitOnSubmitResponse();
 }
 
 function bindEmitOnActivateNode() {
@@ -253,4 +260,8 @@ function bindEmitOnCloseNode() {
 
 function bindEmitOnTaskChanged() {
 	tasks.onSet.push(number => socket.emitTaskChangedEvent(number));
+}
+
+function bindEmitOnSubmitResponse() {
+	tasks.onSubmit.push(answers => socket.emitSubmitResponseEvent(answers));
 }

--- a/js/treetest.js
+++ b/js/treetest.js
@@ -102,7 +102,7 @@ var tasks = {
 			updateProgressBar();
 		} else {
 			$('#hiddenResults').val(JSON.stringify(tasks.answers));
-			window.dispatchEvent(new CustomEvent('submittask', { answers: this.answers }));
+			window.dispatchEvent(new CustomEvent('submittask', { detail: { answers: this.answers } }));
 			$('#submitForm').click();
 		}
 		if (this.idx == this.list.length-1){
@@ -139,7 +139,7 @@ var tasks = {
 			expandToNode(copyOfHistory);
 		}
 
-		window.dispatchEvent(new CustomEvent('taskchanged', { newTaskIndex: number }));
+		window.dispatchEvent(new CustomEvent('taskchanged', { detail: { newTaskIndex: number } }));
 	},
 }
 
@@ -272,11 +272,11 @@ function bindEmitOnCloseNode() {
 }
 
 function bindEmitOnTaskChanged() {
-	window.addEventListener('taskchanged', ({ newTaskIndex }) => socket.emitTaskChangedEvent(newTaskIndex));
+	window.addEventListener('taskchanged', ({ detail }) => socket.emitTaskChangedEvent(detail.newTaskIndex));
 }
 
 function bindEmitOnSubmitResponse() {
-	window.addEventListener('submittask', ({ answers }) => socket.emitSubmitResponseEvent(answers));
+	window.addEventListener('submittask', ({ detail }) => socket.emitSubmitResponseEvent(detail.answers));
 }
 
 function bindEmitOnWindowVisibilityChanged() {

--- a/js/treetest.js
+++ b/js/treetest.js
@@ -140,6 +140,19 @@ var socket = {
 			})
 		})
 	},
+
+	_emitEvent: function(data, eventType) {
+		const json = JSON.stringify({
+			id: crypto.randomUUID(),
+			timestamp: new Date().toISOString(),
+			tree_test_id: document.split('/').pop(),
+			...data,
+		});
+		const emitUntilAcknowledged = () => this._socket
+			.timeout(2000)
+			.emit(eventType, json, (err) => err && emitUntilAcknowledged());
+		emitUntilAcknowledged();
+	},
 }
 
 //---------------------Task List Initialization----------------------

--- a/js/treetest.js
+++ b/js/treetest.js
@@ -136,8 +136,6 @@ var tasks = {
 	onSubmit: [],
 }
 
-const responseId = document.baseURI.split('/').pop();
-
 var socket = {
 	_socket: null,
 
@@ -196,7 +194,7 @@ var socket = {
 		const json = JSON.stringify({
 			id: crypto.randomUUID(),
 			timestamp: new Date().toISOString(),
-			responseId,
+			responseId: document.getElementById('resid').value,
 			...data,
 		});
 		const emitUntilAcknowledged = () => this._socket

--- a/js/treetest.js
+++ b/js/treetest.js
@@ -136,6 +136,8 @@ var tasks = {
 	onSubmit: [],
 }
 
+const responseId = document.baseURI.split('/').pop();
+
 var socket = {
 	_socket: null,
 
@@ -194,7 +196,7 @@ var socket = {
 		const json = JSON.stringify({
 			id: crypto.randomUUID(),
 			timestamp: new Date().toISOString(),
-			response_id: document.baseURI.split('/').pop(),
+			response_id: responseId,
 			...data,
 		});
 		const emitUntilAcknowledged = () => this._socket

--- a/js/treetest.js
+++ b/js/treetest.js
@@ -129,7 +129,9 @@ var tasks = {
 			var copyOfHistory = $.extend(true, [], this.answers[this.idx]);
 			expandToNode(copyOfHistory);
 		}
-	}
+		this.onSet.forEach(callback => callback(number));
+	},
+	onSet: [],
 }
 
 var socket = {
@@ -171,6 +173,10 @@ var socket = {
 			current_task_index: tasks.idx,
 		};
 		this._emitEvent(data, 'close node');
+	},
+
+	emitTaskChangedEvent: function(newTaskIndex) {
+		this._emitEvent({ new_task_index: newTaskIndex }, 'task changed');
 	},
 
 	_emitEvent: function(data, eventType) {
@@ -219,6 +225,7 @@ function bindEvents() {
 	bindEmitOnActivateNode();
 	bindEmitOnOpenNode();
 	bindEmitOnCloseNode();
+	bindEmitOnTaskChanged();
 }
 
 function bindEmitOnActivateNode() {
@@ -242,4 +249,8 @@ function bindEmitOnCloseNode() {
 	$('#tree').on('close_node.jstree', function (_, { node }) {
 		socket.emitCloseNodeEvent(node);
 	});
+}
+
+function bindEmitOnTaskChanged() {
+	tasks.onSet.push(number => socket.emitTaskChangedEvent(number));
 }

--- a/js/treetest.js
+++ b/js/treetest.js
@@ -32,6 +32,7 @@ function initializeTreeViewObject(treeStructure){
 
 	$("#tree").on('ready.jstree', function() {
 		$("#tree").jstree('close_all');
+		bindEvents();
 	});
 }
 
@@ -145,6 +146,30 @@ var socket = {
 		this._emitEvent({}, 'page load');
 	},
 
+	emitActivateNodeEvent: function(node) {
+		const data = {
+			node: $('#tree').jstree().get_path(node),
+			current_task_index: tasks.idx,
+		};
+		this._emitEvent(data, 'activate node');
+	},
+
+	emitOpenNodeEvent: function(node) {
+		const data = {
+			node: $('#tree').jstree().get_path(node),
+			current_task_index: tasks.idx,
+		};
+		this._emitEvent(data, 'open node');
+	},
+
+	emitCloseNodeEvent: function(node) {
+		const data = {
+			node: $('#tree').jstree().get_path(node),
+			current_task_index: tasks.idx,
+		};
+		this._emitEvent(data, 'close node');
+	},
+
 	_emitEvent: function(data, eventType) {
 		const json = JSON.stringify({
 			id: crypto.randomUUID(),
@@ -185,4 +210,33 @@ function setup(input_tasks,input_tree,input_selectableParents,input_closeSibling
 
 	socket.connect();
 	socket.emitPageLoadEvent();
+}
+
+function bindEvents() {
+	bindEmitOnActivateNode();
+	bindEmitOnOpenNode();
+	bindEmitOnCloseNode();
+}
+
+function bindEmitOnActivateNode() {
+	// Fires when the user activates a node (by clicking on it)
+	$('#tree').on('activate_node.jstree', function (_, { node }) {
+		socket.emitActivateNodeEvent(node);
+	});
+}
+
+function bindEmitOnOpenNode() {
+	// Fires when the user opens a parent node to expose its children, either by
+	// activating the parent node itself, or by activating the button next to it
+	$('#tree').on('open_node.jstree', function (_, { node }) {
+		socket.emitOpenNodeEvent(node);
+	});
+}
+
+function bindEmitOnCloseNode() {
+	// Fires when the user close a parent node to hideits children, either by
+	// activating the parent node itself, or by activating the button next to it
+	$('#tree').on('close_node.jstree', function (_, { node }) {
+		socket.emitCloseNodeEvent(node);
+	});
 }

--- a/models/event.js
+++ b/models/event.js
@@ -3,9 +3,9 @@ var mongoose = require('mongoose');
 var Event = new mongoose.Schema({
 	id: String,
 	type: String,
-	iso_timestamp_sent: String,
-	iso_timestamp_received: String,
-	response_id: String,
+	isoTimestampSent: String,
+	isoTimestampReceived: String,
+	responseId: String,
 	data: Object,
 });
 

--- a/models/event.js
+++ b/models/event.js
@@ -1,0 +1,12 @@
+var mongoose = require('mongoose');
+
+var Event = new mongoose.Schema({
+	id: String,
+	type: String,
+	iso_timestamp_sent: String,
+	iso_timestamp_received: String,
+	tree_test_id: String,
+	data: Object,
+});
+
+module.exports = mongoose.model('Event', Event);

--- a/models/event.js
+++ b/models/event.js
@@ -5,7 +5,7 @@ var Event = new mongoose.Schema({
 	type: String,
 	iso_timestamp_sent: String,
 	iso_timestamp_received: String,
-	tree_test_id: String,
+	response_id: String,
 	data: Object,
 });
 

--- a/models/event.js
+++ b/models/event.js
@@ -1,7 +1,7 @@
 var mongoose = require('mongoose');
 
 var Event = new mongoose.Schema({
-	id: String,
+	_id: mongoose.Schema.Types.UUID,
 	type: String,
 	isoTimestampSent: String,
 	isoTimestampReceived: String,

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "passport-local": "^1.0.0",
         "pkginfo": "^0.4.1",
         "plotly.js": "^2.5.1",
+        "socket.io": "^4.7.5",
         "uuid": "^8.3.2",
         "winston": "^3.3.3"
       },
@@ -1832,6 +1833,11 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -1906,6 +1912,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
+      "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/node": {
@@ -2272,6 +2291,14 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
     },
     "node_modules/base64url": {
       "version": "3.0.1",
@@ -3236,6 +3263,18 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/country-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/country-regex/-/country-regex-1.1.0.tgz",
@@ -3839,6 +3878,55 @@
       "dependencies": {
         "once": "^1.4.0"
       }
+    },
+    "node_modules/engine.io": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.4.tgz",
+      "integrity": "sha512-KdVSDKhVKyOi+r5uEabrDLZw2qXStVvCsEB/LN3mw4WFi6Gx50jTyuxYVCwAAC0U46FdnzP/ScKRBTXb/NiEOg==",
+      "dependencies": {
+        "@types/cookie": "^0.4.1",
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.4.1",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.11.0"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.2.tgz",
+      "integrity": "sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
@@ -8888,6 +8976,107 @@
         "npm": ">= 3.0.0"
       }
     },
+    "node_modules/socket.io": {
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.5.tgz",
+      "integrity": "sha512-DmeAkF6cwM9jSfmp6Dr/5/mfMwb5Z5qRrSXLpo3Fq5SqyU8CMF15jIN4ZhfSwu35ksM1qmHZDQ/DK5XTccSTvA==",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.3.2",
+        "engine.io": "~6.5.2",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.4.tgz",
+      "integrity": "sha512-wDNHGXGewWAjQPt3pyeYBtpWSq9cLE5UW1ZUPL/2eGK9jtse/FpXib7epSTsz0Q0m+6sg6Y4KtcFTlah1bdOVg==",
+      "dependencies": {
+        "debug": "~4.3.4",
+        "ws": "~8.11.0"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
     "node_modules/socks": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.1.tgz",
@@ -9942,6 +10131,26 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "pkginfo": "^0.4.1",
     "plotly.js": "^2.5.1",
     "@popperjs/core": "^2.11.8",
+    "socket.io": "^4.7.5",
     "uuid": "^8.3.2",
     "winston": "^3.3.3"
   },

--- a/server/socket.js
+++ b/server/socket.js
@@ -1,4 +1,5 @@
 const { Server } = require('socket.io');
+const Event = require('mongoose').model('Event');
 const logger = require('./logger.js');
 
 function setupSocketServer(httpServer) {
@@ -10,6 +11,48 @@ function setupSocketServer(httpServer) {
 			logger.info('Socket disconnected: ' + socket.id);
 		});
 	});
+}
+
+function saveEventToDb(eventType) {
+	return function(eventJson) {
+		const data = JSON.parse(eventJson);
+		const isoTimestampReceived = new Date().toISOString();
+
+		Event.findOne({ id: data.id }, (err, event) => {
+			if (err) {
+				logger.error('server/socket.js: error finding Event:', err);
+				return;
+			}
+
+			if (event) {
+				// If the same event gets re-posted, don't overwrite it
+				return;
+			}
+
+			const eventInDb = new Event();
+			eventInDb.id = extract(data, 'id');
+			eventInDb.type = eventType;
+			eventInDb.iso_timestamp_sent = extract(data, 'timestamp');
+			eventInDb.iso_timestamp_received = isoTimestampReceived;
+			eventInDb.tree_test_id = extract(data, 'tree_test_id');
+			eventInDb.data = data;
+
+			eventInDb.save((err) => {
+				if (err) {
+					logger.error('server/socket.js: error saving Event:', err);
+					throw err;
+				}
+
+				logger.info('Saved Event to database:', eventInDb.id);
+			});
+		});
+	};
+}
+
+function extract(object, property) {
+	const value = object[property];
+	delete object[property];
+	return value;
 }
 
 module.exports = { setupSocketServer };

--- a/server/socket.js
+++ b/server/socket.js
@@ -41,9 +41,9 @@ function saveEventToDb(eventType) {
 			const eventInDb = new Event();
 			eventInDb.id = extract(data, 'id');
 			eventInDb.type = eventType;
-			eventInDb.iso_timestamp_sent = extract(data, 'timestamp');
-			eventInDb.iso_timestamp_received = isoTimestampReceived;
-			eventInDb.response_id = extract(data, 'response_id');
+			eventInDb.isoTimestampSent = extract(data, 'timestamp');
+			eventInDb.isoTimestampReceived = isoTimestampReceived;
+			eventInDb.responseId = extract(data, 'responseId');
 			eventInDb.data = data;
 
 			eventInDb.save((err) => {

--- a/server/socket.js
+++ b/server/socket.js
@@ -6,7 +6,7 @@ function setupSocketServer(httpServer) {
 	const server = new Server(httpServer);
 
 	server.on('connect', (socket) => {
-		logger.info('Socket connected: ' + socket.id);
+		logger.info(`Socket connected: ${socket.id}`);
 		socket.on('disconnect', (reason) => {
 			logger.info(`Socket disconnected: ${socket.id}. Reason: ${reason}`);
 		});
@@ -28,7 +28,8 @@ function saveEventToDb(eventType) {
 
 		Event.findOne({ id: data.id }, (err, event) => {
 			if (err) {
-				logger.error('server/socket.js: error finding Event:', err);
+				const errString = typeof(err) === 'string' ? err : JSON.stringify(err);
+				logger.error(`server/socket.js: error finding Event: ${errString}`);
 				return;
 			}
 
@@ -47,11 +48,12 @@ function saveEventToDb(eventType) {
 
 			eventInDb.save((err) => {
 				if (err) {
-					logger.error('server/socket.js: error saving Event:', err);
+					const errString = typeof(err) === 'string' ? err : JSON.stringify(err);
+					logger.error(`server/socket.js: error saving Event: ${errString}`);
 					throw err;
 				}
 
-				logger.info('Saved Event to database:', eventInDb.id);
+				logger.info(`Saved Event to database: ${eventInDb.id}`);
 			});
 		});
 	};

--- a/server/socket.js
+++ b/server/socket.js
@@ -15,6 +15,7 @@ function setupSocketServer(httpServer) {
 		socket.on('activate node', saveEventToDb('activate node'));
 		socket.on('open node', saveEventToDb('open node'));
 		socket.on('close node', saveEventToDb('close node'));
+		socket.on('task changed', saveEventToDb('task changed'));
 	});
 }
 

--- a/server/socket.js
+++ b/server/socket.js
@@ -3,9 +3,9 @@ const Event = require('mongoose').model('Event');
 const logger = require('./logger.js');
 
 function setupSocketServer(httpServer) {
-	const socketIo = new Server(httpServer);
+	const server = new Server(httpServer);
 
-	socketIo.on('connect', (socket) => {
+	server.on('connect', (socket) => {
 		logger.info('Socket connected: ' + socket.id);
 		socket.on('disconnect', () => {
 			logger.info('Socket disconnected: ' + socket.id);

--- a/server/socket.js
+++ b/server/socket.js
@@ -10,6 +10,8 @@ function setupSocketServer(httpServer) {
 		socket.on('disconnect', () => {
 			logger.info('Socket disconnected: ' + socket.id);
 		});
+
+		socket.on('page load', saveEventToDb('page load'));
 	});
 }
 

--- a/server/socket.js
+++ b/server/socket.js
@@ -7,8 +7,8 @@ function setupSocketServer(httpServer) {
 
 	server.on('connect', (socket) => {
 		logger.info('Socket connected: ' + socket.id);
-		socket.on('disconnect', () => {
-			logger.info('Socket disconnected: ' + socket.id);
+		socket.on('disconnect', (reason) => {
+			logger.info(`Socket disconnected: ${socket.id}. Reason: ${reason}`);
 		});
 
 		socket.on('page load', saveEventToDb('page load'));

--- a/server/socket.js
+++ b/server/socket.js
@@ -16,6 +16,7 @@ function setupSocketServer(httpServer) {
 		socket.on('open node', saveEventToDb('open node'));
 		socket.on('close node', saveEventToDb('close node'));
 		socket.on('task changed', saveEventToDb('task changed'));
+		socket.on('submit response', saveEventToDb('submit response'));
 	});
 }
 

--- a/server/socket.js
+++ b/server/socket.js
@@ -12,6 +12,9 @@ function setupSocketServer(httpServer) {
 		});
 
 		socket.on('page load', saveEventToDb('page load'));
+		socket.on('activate node', saveEventToDb('activate node'));
+		socket.on('open node', saveEventToDb('open node'));
+		socket.on('close node', saveEventToDb('close node'));
 	});
 }
 

--- a/server/socket.js
+++ b/server/socket.js
@@ -1,0 +1,15 @@
+const { Server } = require('socket.io');
+const logger = require('./logger.js');
+
+function setupSocketServer(httpServer) {
+	const socketIo = new Server(httpServer);
+
+	socketIo.on('connect', (socket) => {
+		logger.info('Socket connected: ' + socket.id);
+		socket.on('disconnect', () => {
+			logger.info('Socket disconnected: ' + socket.id);
+		});
+	});
+}
+
+module.exports = { setupSocketServer };

--- a/server/socket.js
+++ b/server/socket.js
@@ -43,7 +43,7 @@ function saveEventToDb(eventType) {
 			eventInDb.type = eventType;
 			eventInDb.iso_timestamp_sent = extract(data, 'timestamp');
 			eventInDb.iso_timestamp_received = isoTimestampReceived;
-			eventInDb.tree_test_id = extract(data, 'tree_test_id');
+			eventInDb.response_id = extract(data, 'response_id');
 			eventInDb.data = data;
 
 			eventInDb.save((err) => {

--- a/server/socket.js
+++ b/server/socket.js
@@ -17,6 +17,7 @@ function setupSocketServer(httpServer) {
 		socket.on('close node', saveEventToDb('close node'));
 		socket.on('task changed', saveEventToDb('task changed'));
 		socket.on('submit response', saveEventToDb('submit response'));
+		socket.on('window visibility changed', saveEventToDb('window visibility changed'));
 	});
 }
 

--- a/server/socket.js
+++ b/server/socket.js
@@ -26,7 +26,7 @@ function saveEventToDb(eventType) {
 		const data = JSON.parse(eventJson);
 		const isoTimestampReceived = new Date().toISOString();
 
-		Event.findOne({ id: data.id }, (err, event) => {
+		Event.findOne({ _id: data.id }, (err, event) => {
 			if (err) {
 				const errString = typeof(err) === 'string' ? err : JSON.stringify(err);
 				logger.error(`server/socket.js: error finding Event: ${errString}`);
@@ -39,7 +39,7 @@ function saveEventToDb(eventType) {
 			}
 
 			const eventInDb = new Event();
-			eventInDb.id = extract(data, 'id');
+			eventInDb._id = extract(data, 'id');
 			eventInDb.type = eventType;
 			eventInDb.isoTimestampSent = extract(data, 'timestamp');
 			eventInDb.isoTimestampReceived = isoTimestampReceived;

--- a/views/treetest/view.ejs
+++ b/views/treetest/view.ejs
@@ -8,8 +8,9 @@
 		<!-- custom css -->
 		<link rel="stylesheet" type="text/css" href="/css/treetest.css" />
 		<title>Kort Treetest</title>
-		<script type="text/javascript" src="/js/treetest.js"/></script>
+		<script type="text/javascript" src="/js/treetest.js"></script>
 		<script type="text/javascript" src="/js/treetest-view.js"></script>
+		<script type="text/javascript" src="/socket.io/socket.io.js"></script>
 	</head>
 
 	<body class="background-darkbluegray">


### PR DESCRIPTION
[Ticket AIAT-129](https://scottlogic.atlassian.net/browse/AIAT-129?atlOrigin=eyJpIjoiZGEwZTJmMGQ3Y2EyNDY1ZThmNGY4ZDhlYzkwYzBjYWMiLCJwIjoiaiJ9)

Uses [socket.io](https://socket.io) to emit a stream of events from the tree test study frontend to the server.

Records these events:

- page load
- activate node
- open node (when you expand a parent node to show its children: sometimes coincides with activating it, but not always)
- close node (when you fold in a parent node to hide its children: sometimes coincides with activating it, but not always)
- task changed
- submit response
- window visibility changed

All events include **at least** these data:

- time sent
- time received
- tree test ID
- event type

The client will always try and make the server consistent, even if the connection drops. I've used the [acknowledgements and timeouts features of socket.io](https://socket.io/docs/v4/emitting-events/#with-timeout) to achieve this.

I couldn't exactly achieve one of the AC: to emit an event when the user closes the browser. The [Window beforeunload event](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event) is close, but according to MDN it is unreliable. Instead I used the [Document visibilitychange event](https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event). As well as firing when the user closes the tab or window, it also fires when the user changes tab or minimises the window. I think this is OK, since I think the intention was to identify when the user is no longer actively working on the task, and if the user changes tab or minimises the window, they probably aren't actively working on the task any more. One weakness I've found of this approach is that it doesn't fire if you kill the browser process from Windows Task Manager, and I'm guessing it won't fire if the browser crashes, so we won't always be able to correctly infer when the user was working on the task.