### PR TITLE
AITAT-190 - (fix) Increase request rate for limiter

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,13 +43,13 @@ const flash = require('connect-flash');
 var logger = require('./server/logger.js');
 const path = require('path');
 
-// set up rate limiter: maximum of 120 requests per 10 seconds
+// set up rate limiter: maximum of 500 requests per 10 seconds
 var rateLimit = require('express-rate-limit');
 var limiter = rateLimit({
   windowMs: 1*10*1000, // 10 seconds
-  max: 120
+  max: 500, // limit each IP to 500 requests per windowMs
 });
-// apply rate limiter to all requests
+//apply rate limiter to all requests
 app.use(limiter);
 
 require('pkginfo')(module, 'version');


### PR DESCRIPTION
From initial investigation it looks like Kort uses ‘express-rate-limit’ middleware with the maximum number of requests has been set to 120 in a 10 second period.  I have currently increased the requests to 500 per time period (It's a guess at the number of requests needed, possible trial and error to find a suitable number may be needed.) I don't think we should remove this middleware outright as it opens ourselves up to DOS attacks and some performance issues further down the line. 